### PR TITLE
DTSO-15909 - Custom name functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ module "application_insights" {
 | <a name="input_env"></a> [env](#input\_env) | Environment value | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | Target Azure location to deploy the resource | `string` | `"UK South"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The default name will be product+env, you can override the product part by setting this | `string` | `null` | no |
+| <a name="override_name"></a> [name](#input\_override\_name) | Allows setting of fully custom name, ideally only to be used for exisitng instances of App Insights | `string` | `null` | no |
 | <a name="input_product"></a> [product](#input\_product) | https://hmcts.github.io/glossary/#product | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of existing resource group to deploy resources into | `string` | n/a | yes |
 | <a name="input_sampling_percentage"></a> [sampling\_percentage](#input\_sampling\_percentage) | Specifies the percentage of the data produced by the monitored application that is sampled for Application Insights telemetry. | `number` | `100` | no |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ module "application_insights" {
 | <a name="input_env"></a> [env](#input\_env) | Environment value | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | Target Azure location to deploy the resource | `string` | `"UK South"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The default name will be product+env, you can override the product part by setting this | `string` | `null` | no |
-| <a name="override_name"></a> [name](#input\_override\_name) | Allows setting of fully custom name, ideally only to be used for exisitng instances of App Insights | `string` | `null` | no |
+| <a name="override_name"></a> [override_name](#input\_override\_name) | Allows setting of fully custom name, ideally only to be used for exisitng instances of App Insights | `string` | `null` | no |
 | <a name="input_product"></a> [product](#input\_product) | https://hmcts.github.io/glossary/#product | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of existing resource group to deploy resources into | `string` | n/a | yes |
 | <a name="input_sampling_percentage"></a> [sampling\_percentage](#input\_sampling\_percentage) | Specifies the percentage of the data produced by the monitored application that is sampled for Application Insights telemetry. | `number` | `100` | no |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ module "application_insights" {
 | <a name="input_env"></a> [env](#input\_env) | Environment value | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | Target Azure location to deploy the resource | `string` | `"UK South"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The default name will be product+env, you can override the product part by setting this | `string` | `null` | no |
-| <a name="override_name"></a> [override\_name](#input\_override\_name) | Allows setting of fully custom resource name, ideally only to be used for existing instances of App Insights | `string` | `null` | no |
+| <a name="input_override_name"></a> [override\_name](#input\_override\_name) | The default name will be product+env, this override enables a fully custom name | `string` | `null` | no |
 | <a name="input_product"></a> [product](#input\_product) | https://hmcts.github.io/glossary/#product | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of existing resource group to deploy resources into | `string` | n/a | yes |
 | <a name="input_sampling_percentage"></a> [sampling\_percentage](#input\_sampling\_percentage) | Specifies the percentage of the data produced by the monitored application that is sampled for Application Insights telemetry. | `number` | `100` | no |

--- a/app-insights.tf
+++ b/app-insights.tf
@@ -1,5 +1,5 @@
 locals {
-  name = var.name == null ? "${var.product}-${var.env}" : "${var.name}-${var.env}"
+  name = var.override_name == null ?  (var.name == null ? "${var.product}-${var.env}" : "${var.name}-${var.env}") : var.override_name
 }
 
 module "log_analytics_workspace_id" {

--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -15,6 +15,12 @@ variable "name" {
   type        = string
 }
 
+variable "override_name" {
+  description = "The default name will be product+env, this override enables a fully custom name" #the primary use case for this is to enable exisiting App Insights to be moved to the module, without redeployment.
+  default     = null
+  type        = string
+}
+
 variable "application_type" {
   default     = "web" # most of our instances have historically used web, even if other might be more appropriate
   description = "Specifies the type of Application Insights to create. Valid values are `java` for Java web, `Node.JS` for Node.js, `other` for General, and `web` for ASP.NET"


### PR DESCRIPTION
### Jira link (if applicable)
DTSPO-15909


### Change description ###
Optional input variable to allow setting of fully custom resource name. Some existing resources can't be migrated to the new terraform module without being destroyed, due to incompatible resource name.
