### PR TITLE
DTSPO-16745 - Changing Alert name to include app insight name to make it unique

### DIFF
--- a/alert.tf
+++ b/alert.tf
@@ -13,7 +13,7 @@ data "azurerm_subscription" "current" {
 }
 
 resource "azurerm_monitor_activity_log_alert" "main" {
-  name                = var.env == "preview" ? "Application Insights daily cap reached - preview" : "Application Insights daily cap reached"
+  name                = "Application Insights daily cap reached - ${local.name}"
   resource_group_name = var.resource_group_name
   scopes              = [azurerm_application_insights.this.id]
   description         = "Monitors for application insight reaching it's daily cap."


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16745

### Change description ###

Allows to keep uniuqe alert name as some of the teams has got multiple app insights deployed using this module.
example - 
https://github.com/hmcts/et-pet-shared-infrastructure/blob/b56b178f2247c24b0a9402102f6566f3293c4698/main.tf 
### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
