### PR TITLE
Location now required in azurerm_monitor_activity_log_alert

### DIFF
--- a/alert.tf
+++ b/alert.tf
@@ -16,6 +16,7 @@ resource "azurerm_monitor_activity_log_alert" "main" {
   count               = var.alert_limit_reached ? 0 : 1
   name                = "Application Insights daily cap reached - ${local.name}"
   resource_group_name = var.resource_group_name
+  location            = var.location
   scopes              = [azurerm_application_insights.this.id]
   description         = "Monitors for application insight reaching it's daily cap."
 


### PR DESCRIPTION
### Change Description

For 4.x azurerm provider changes
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide#azurerm_monitor_activity_log_alert

### Jira link

Relating to DTSPO-18682 (https://tools.hmcts.net/jira/browse/DTSPO-18682)

### Testing done

https://github.com/hmcts/service-auth-provider-app/pull/998/files
https://build.hmcts.net/blue/organizations/jenkins/HMCTS_j_to_z%2Fservice-auth-provider-app/detail/PR-998/1/pipeline/378
Passing, alerts would be recreated as default location was global before but this would update it
location            = "global" -> "westeurope" # forces replacement

<!-- Comment:
Provide a clear description of how this change was tested.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
