### PR TITLE
fix so alert has global as default (not all locations available for alerts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ module "application_insights" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alert_limit_reached"></a> [alert\_limit\_reached](#input\_alert\_limit\_reached) | Specifies whether the limit of 100 Activity Log Alerts has been met in the current subscription. Setting to true will create a Log Search Alert instead | `bool` | `false` | no |
+| <a name="input_alert_location"></a> [alert\_location](#input\_alert\_location) | Target Azure location to deploy the alert | `string` | `"global"` | no |
 | <a name="input_application_type"></a> [application\_type](#input\_application\_type) | Specifies the type of Application Insights to create. Valid values are `java` for Java web, `Node.JS` for Node.js, `other` for General, and `web` for ASP.NET | `string` | `"web"` | no |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Common tags to be applied to resources | `map(string)` | n/a | yes |
 | <a name="input_daily_data_cap_in_gb"></a> [daily\_data\_cap\_in\_gb](#input\_daily\_data\_cap\_in\_gb) | Specifies the Application Insights component daily data volume cap in GB | `number` | `50` | no |
@@ -69,7 +70,6 @@ module "application_insights" {
 | <a name="input_product"></a> [product](#input\_product) | https://hmcts.github.io/glossary/#product | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of existing resource group to deploy resources into | `string` | n/a | yes |
 | <a name="input_sampling_percentage"></a> [sampling\_percentage](#input\_sampling\_percentage) | Specifies the percentage of the data produced by the monitored application that is sampled for Application Insights telemetry. | `number` | `100` | no |
-| <a name="input_alert_location"></a> [location](#input\_alert\_location) | Target Azure location to deploy the alert | `string` | `"global"` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ module "application_insights" {
 | <a name="input_product"></a> [product](#input\_product) | https://hmcts.github.io/glossary/#product | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of existing resource group to deploy resources into | `string` | n/a | yes |
 | <a name="input_sampling_percentage"></a> [sampling\_percentage](#input\_sampling\_percentage) | Specifies the percentage of the data produced by the monitored application that is sampled for Application Insights telemetry. | `number` | `100` | no |
+| <a name="input_alert_location"></a> [location](#input\_alert\_location) | Target Azure location to deploy the alert | `string` | `"global"` | no |
 
 ## Outputs
 

--- a/alert.tf
+++ b/alert.tf
@@ -16,7 +16,7 @@ resource "azurerm_monitor_activity_log_alert" "main" {
   count               = var.alert_limit_reached ? 0 : 1
   name                = "Application Insights daily cap reached - ${local.name}"
   resource_group_name = var.resource_group_name
-  location            = var.location
+  location            = var.alert_location
   scopes              = [azurerm_application_insights.this.id]
   description         = "Monitors for application insight reaching it's daily cap."
 

--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -50,3 +50,9 @@ variable "alert_limit_reached" {
   type        = bool
   default     = false
 }
+
+variable "alert_location" {
+  description = "Target Azure location to deploy the alert"
+  type        = string
+  default     = "global"
+}


### PR DESCRIPTION
### Jira link

[DTSPO-18682](https://tools.hmcts.net/jira/browse/DTSPO-18682)

### Change description

Fix for:
The provided location 'uksouth' is not available for resource type 'microsoft.insights/activityLogAlerts'. List of available regions for the resource type is 'global,westeurope,northeurope'.

Another var added, defaults to global

### Testing done


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
