### PR TITLE
DTSPO-27514: Replace spaces with hyphens in monitor alert names for A…

### DIFF
--- a/alert.tf
+++ b/alert.tf
@@ -14,7 +14,7 @@ data "azurerm_subscription" "current" {
 
 resource "azurerm_monitor_activity_log_alert" "main" {
   count               = var.alert_limit_reached ? 0 : 1
-  name                = "Application Insights daily cap reached - ${local.name}"
+  name                = "Application-Insights-daily-cap-reached-${local.name}"
   resource_group_name = var.resource_group_name
   location            = var.alert_location
   scopes              = [azurerm_application_insights.this.id]
@@ -41,7 +41,7 @@ resource "azurerm_monitor_activity_log_alert" "main" {
 
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "main" {
   count                = var.alert_limit_reached ? 1 : 0
-  name                 = "Application Insights daily cap reached - ${local.name}"
+  name                 = "Application-Insights-daily-cap-reached-${local.name}"
   resource_group_name  = var.resource_group_name
   location             = var.location
   evaluation_frequency = "P1D"


### PR DESCRIPTION
…zure provider v4.0 compatibility

### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-27514

### Change description
Fix: replace spaces with hyphens in monitor alert names for Azure provider v4.0 compatibility

Resolves naming validation errors introduced in Azure Terraform provider v4.0 which enforces stricter naming rules for monitor resources
- Names must contain only alphanumeric characters, hyphens, underscores, periods, and parentheses

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
